### PR TITLE
[#15] 作業ディレクトリを pipenv 編集可能な依存関係として追加

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 mock = "*"
 nose = "*"
+unknown = {editable = true,path = "."}
 
 [packages]
 Sphinx = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c19be43812334711e607444929898d43f9361adbbe203957a9b279b281a1bdc"
+            "sha256": "e7259c23809ac8c47e65bf9ce27076aa995ceee9c945715ad7d852576f6d5961"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -267,11 +267,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:22538e1bbe62b407cf5a8aabe1bb15848aa66bb79559f42f5202bbce6b757a69",
-                "sha256:f9a79e746b87921cabc3baa375199c6076d1270cee53915dbd24fdbeaaacc427"
+                "sha256:0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845",
+                "sha256:839a3ed6f6b092bb60f492024489cc9e6991360fb9f52ed6361acd510d261069"
             ],
             "index": "pypi",
-            "version": "==2.1.2"
+            "version": "==2.2.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -347,6 +347,10 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "unknown": {
+            "editable": true,
+            "path": "."
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
## 対応内容

- `setup.py` の追加
- `pipenv install --dev -e .` で `Pipfile` と `Pipfile.lock` を更新