### PR TITLE
[#22] show_mean_std_diagram() の引数変更版を追加

### DIFF
--- a/evmoon/chart.py
+++ b/evmoon/chart.py
@@ -25,17 +25,24 @@ def show_rate_of_return_chart(fund_codes: list,
     ax.set_ylabel("Rate of Return")
 
 
-def show_mean_std_diagram(fund_codes: list,
-                          start_period: datetime.date = None,
-                          end_period: datetime.date = None,
-                          investment_period_days: int = 5,
-                          num_random_feasible_set: int = 0) -> None:
+def show_mean_std_diagram_with_time_series(fund_codes: list,
+                                           start_period: datetime.date = None,
+                                           end_period: datetime.date = None,
+                                           investment_period_days: int = 5,
+                                           num_random_feasible_set: int = 0) -> None:
     df_return = calc_rate_of_return(fund_codes, start_period, end_period, investment_period_days)
     matrix = df_return.as_matrix()
 
     mean = matrix.mean(axis=0)
-    std = matrix.std(axis=0, ddof=0)
+    cov = np.cov(matrix, rowvar=False, ddof=0)
 
+    show_mean_std_diagram(fund_codes, mean, cov, num_random_feasible_set)
+
+
+def show_mean_std_diagram(fund_codes: list,
+                          mean: np.ndarray,
+                          cov: np.ndarray,
+                          num_random_feasible_set: int = 0) -> None:
     fig = plt.figure()
     ax = fig.add_subplot(111)
 
@@ -43,12 +50,17 @@ def show_mean_std_diagram(fund_codes: list,
 
     # ランダムな実現可能集合の要素数が正の場合はそれらもポートフォリオとして表示する
     if num_random_feasible_set > 0:
-        cov = np.cov(matrix, rowvar=False, ddof=0)
         portfolio_mean_std_weight = calc_random_weight_portfolios(num_random_feasible_set, mean, cov)
         ax.scatter(x=portfolio_mean_std_weight[1], y=portfolio_mean_std_weight[0], c='lightskyblue', s=5, marker='o',
                    label='random feasible set')
 
-    ax.scatter(x=std, y=mean, c='navy', s=16, marker='x', label='fund')
+    # 各ファンドをプロット
+    stddev = np.power(cov.diagonal(), 2)
+    ax.scatter(x=stddev, y=mean, c='navy', s=16, marker='x', label='fund')
+
+    for i, fund_code in enumerate(fund_codes):
+        ax.annotate(fund_code, stddev[i], mean[i])
+
     ax.legend()
 
     plt.xlabel('std')

--- a/evmoon/chart.py
+++ b/evmoon/chart.py
@@ -59,7 +59,7 @@ def show_mean_std_diagram(fund_codes: list,
     ax.scatter(x=stddev, y=mean, c='navy', s=16, marker='x', label='fund')
 
     for i, fund_code in enumerate(fund_codes):
-        ax.annotate(fund_code, stddev[i], mean[i])
+        ax.annotate(fund_code, xy=(stddev[i], mean[i]))
 
     ax.legend()
 

--- a/evmoon/chart.py
+++ b/evmoon/chart.py
@@ -55,7 +55,7 @@ def show_mean_std_diagram(fund_codes: list,
                    label='random feasible set')
 
     # 各ファンドをプロット
-    stddev = np.power(cov.diagonal(), 2)
+    stddev = np.sqrt(cov.diagonal())
     ax.scatter(x=stddev, y=mean, c='navy', s=16, marker='x', label='fund')
 
     for i, fund_code in enumerate(fund_codes):


### PR DESCRIPTION
#22 

## 対応内容

- `evmoon.chart.show_mean_std_diagram()` の引数にリターンの配列とリスクの共分散行列を取るパターンを用意
- 元の引数をとるものは `show_mean_std_diagram_with_time_series()` に rename した
- グラフ上でファンドの annotation を追加
